### PR TITLE
Remove resolver warning message by defining the resolver version.

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,6 +5,9 @@ description = "A Tauri App"
 authors = ["you"]
 edition = "2021"
 
+[workspace]
+resolver = "2"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]


### PR DESCRIPTION
The fix will remove this warning by setting the resolver to 2.
`virtual workspace defaulting to 'resolver = "1"' despite one or more workspace members being on edition 2021 which implies 'resolver = "2"'
See: [Resolver versions](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions)